### PR TITLE
Add support for Rails 4.2.0

### DIFF
--- a/payday.gemspec
+++ b/payday.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Payday is a library for rendering invoices. At present it supports rendering invoices to pdfs, but we're planning on adding support for other formats in the near future.}
 
   s.add_dependency("prawn", "~> 1.0.0")
-  s.add_dependency("money", "~> 6.1.1")
+  s.add_dependency("money", "~> 6.1")
   s.add_dependency("prawn-svg", "~> 0.15.0.0")
   s.add_dependency("i18n", ">= 0.6.9")
 


### PR DESCRIPTION
Relax money gem restriction to major version number only. This gem has regular non-breaking minor version updates including support for new Rails versions (i18n dependency).

Tests passing for money gem v6.5.0.