### PR TITLE
Vat per line & font config support

### DIFF
--- a/lib/generators/payday/setup/templates/migration.rb
+++ b/lib/generators/payday/setup/templates/migration.rb
@@ -14,7 +14,7 @@ class CreatePaydayTables < ActiveRecord::Migration
       t.integer :quantity     # can also be :decimal or :float - just needs to be numeric
 
       t.references :<%= options.invoice_name.underscore %>
-
+      t.float :tax
       t.timestamps
     end
   end

--- a/lib/payday/config.rb
+++ b/lib/payday/config.rb
@@ -3,6 +3,7 @@ module Payday
   # Payday::Config.default.company_name = "Awesome Corp".
   class Config
     attr_accessor :invoice_logo, :company_name, :company_details, :date_format, :currency, :pdf_font_families, :pdf_font, :pdf_font_size, :bank_account
+    attr_accessor :default_tax
 
     # Sets the page size to use. See the
     # {http://prawn.majesticseacreature.com/docs/0.10.2/Prawn/Document/PageGeometry.html Prawn documentation} for valid
@@ -28,6 +29,7 @@ module Payday
       self.page_size = "LETTER"
       self.pdf_font_size = 8
       self.pdf_font = "Helvetica-Bold"
+      self.default_tax = 0.0
     end
 
     # Internal: Contruct a new config object.

--- a/lib/payday/config.rb
+++ b/lib/payday/config.rb
@@ -2,7 +2,7 @@ module Payday
   # Configuration for Payday. This is a singleton, so to set the company_name you would call
   # Payday::Config.default.company_name = "Awesome Corp".
   class Config
-    attr_accessor :invoice_logo, :company_name, :company_details, :date_format, :currency, :pdf_font_families, :pdf_font, :pdf_font_size
+    attr_accessor :invoice_logo, :company_name, :company_details, :date_format, :currency, :pdf_font_families, :pdf_font, :pdf_font_size, :bank_account
 
     # Sets the page size to use. See the
     # {http://prawn.majesticseacreature.com/docs/0.10.2/Prawn/Document/PageGeometry.html Prawn documentation} for valid
@@ -22,6 +22,7 @@ module Payday
       self.invoice_logo = File.join(File.dirname(__FILE__), "..", "..", "spec", "assets", "default_logo.png")
       self.company_name = "Awesome Corp"
       self.company_details = "awesomecorp@commondream.net"
+      self.bank_account = "1234567890/1234"
       self.date_format = "%B %e, %Y"
       self.currency = "USD"
       self.page_size = "LETTER"

--- a/lib/payday/config.rb
+++ b/lib/payday/config.rb
@@ -25,7 +25,7 @@ module Payday
       self.date_format = "%B %e, %Y"
       self.currency = "USD"
       self.page_size = "LETTER"
-      self.pdf_font_size = "8"
+      self.pdf_font_size = 8
       self.pdf_font = "Helvetica-Bold"
     end
 

--- a/lib/payday/config.rb
+++ b/lib/payday/config.rb
@@ -2,7 +2,7 @@ module Payday
   # Configuration for Payday. This is a singleton, so to set the company_name you would call
   # Payday::Config.default.company_name = "Awesome Corp".
   class Config
-    attr_accessor :invoice_logo, :company_name, :company_details, :date_format, :currency
+    attr_accessor :invoice_logo, :company_name, :company_details, :date_format, :currency, :pdf_font_families, :pdf_font, :pdf_font_size
 
     # Sets the page size to use. See the
     # {http://prawn.majesticseacreature.com/docs/0.10.2/Prawn/Document/PageGeometry.html Prawn documentation} for valid
@@ -25,6 +25,8 @@ module Payday
       self.date_format = "%B %e, %Y"
       self.currency = "USD"
       self.page_size = "LETTER"
+      self.pdf_font_size = "8"
+      self.pdf_font = "Helvetica-Bold"
     end
 
     # Internal: Contruct a new config object.

--- a/lib/payday/invoice.rb
+++ b/lib/payday/invoice.rb
@@ -4,7 +4,7 @@ module Payday
     include Payday::Invoiceable
 
     attr_accessor :invoice_number, :bill_to, :ship_to, :notes, :line_items, :shipping_rate, :shipping_description,
-      :tax_rate, :tax_description, :due_at, :paid_at, :refunded_at, :currency, :invoice_details, :invoice_date
+      :tax_rate, :tax_description, :due_at, :paid_at, :refunded_at, :currency, :invoice_details, :invoice_date, :tax_date
 
     def initialize(options =  {})
       self.invoice_number = options[:invoice_number] || nil
@@ -22,6 +22,7 @@ module Payday
       self.currency = options[:currency] || nil
       self.invoice_details = options[:invoice_details] || []
       self.invoice_date = options[:invoice_date] || nil
+      self.tax_date = options[:tax_date] || nil
     end
 
     # The tax rate that we're applying, as a BigDecimal

--- a/lib/payday/invoiceable.rb
+++ b/lib/payday/invoiceable.rb
@@ -23,6 +23,10 @@ module Payday::Invoiceable
     line_items.reduce(BigDecimal.new("0")) { |result, item| result += item.amount }
   end
 
+  def taxes
+    line_items.group(:tax).sum("quantity*price")
+  end
+
   # The tax for this invoice, as a BigDecimal
   def tax
     if defined?(tax_rate)

--- a/lib/payday/line_item.rb
+++ b/lib/payday/line_item.rb
@@ -7,7 +7,7 @@ module Payday
   class LineItem
     include LineItemable
 
-    attr_accessor :description, :quantity, :display_quantity, :display_price, :price
+    attr_accessor :description, :quantity, :display_quantity, :display_price, :price, :tax
 
     # Initializes a new LineItem
     def initialize(options = {})
@@ -15,6 +15,7 @@ module Payday
       self.display_quantity = options[:display_quantity]
       self.display_price = options[:display_price]
       self.price = options[:price] || "0.00"
+      self.tax = options[:tax] || Payday::Config.default.default_tax || 0.00
       self.description = options[:description] || ""
     end
 

--- a/lib/payday/line_itemable.rb
+++ b/lib/payday/line_itemable.rb
@@ -5,4 +5,13 @@ module Payday::LineItemable
   def amount
     price * quantity
   end
+
+  def amount_tax
+    price * quantity * (1 + ( tax? ? tax : 0))
+  end
+
+  def tax_percent
+    "#{(tax * 100).to_s}%"
+  end
+
 end

--- a/lib/payday/locale/cs.yml
+++ b/lib/payday/locale/cs.yml
@@ -1,0 +1,28 @@
+cs:
+  payday:
+    status:
+      paid: ZAPLACENO
+      overdue: PO SPLATNOSTI
+      refunded: STORNO
+    invoice:
+      bill_to: "Odběratel"
+      ship_to: "Doručovací adresa:"
+      invoice_no: "Faktura č.:"
+      invoice_date: "Datum vystavení:"
+      refunded_date: "Datum storna:"
+      vat_date: "Datum uskutečnění plnění:"
+      due_date: "Datum splatnosti:"
+      paid_date: "Datum platby:"
+      subtotal: "Mezisoučet bez DPH:"
+      tax: "DPH"
+      total: "Celkem:"
+      variable_symbol: "Variabilní symbol:"
+      bank_account: "Číslo účtu:"
+      notes: Poznámka
+    line_item:
+      description: Popis
+      unit_price: Cena za MJ
+      quantity: Počet
+      amount: Cena
+      amount_vat: Cena s DPH
+      tax: DPH

--- a/lib/payday/locale/cs.yml
+++ b/lib/payday/locale/cs.yml
@@ -5,6 +5,7 @@ cs:
       overdue: PO SPLATNOSTI
       refunded: STORNO
     invoice:
+      title: "Faktura - daňový doklad"
       bill_to: "Odběratel"
       ship_to: "Doručovací adresa:"
       invoice_no: "Faktura č.:"

--- a/lib/payday/locale/en.yml
+++ b/lib/payday/locale/en.yml
@@ -5,6 +5,7 @@ en:
       overdue: OVERDUE
       refunded: REFUNDED
     invoice:
+      title: Invoice
       bill_to: Bill To
       ship_to: Ship To
       invoice_no: "Invoice #:"

--- a/lib/payday/locale/en.yml
+++ b/lib/payday/locale/en.yml
@@ -10,12 +10,16 @@ en:
       invoice_no: "Invoice #:"
       due_date: "Due Date:"
       paid_date: "Paid Date:"
+      invoice_date: "Invoice Date:"
+      vat_date: "Tax Date:"
       subtotal: "Subtotal:"
       shipping: "Shipping:"
       tax: "Tax:"
-      total: "Total:"
+      total: "Total with tax:"
     line_item:
       description: Description
       unit_price: Unit Price
       quantity: Quantity
       amount: Amount
+      tax: Tax
+      amount_tax: 'Amount+Tax'

--- a/lib/payday/pdf_renderer.rb
+++ b/lib/payday/pdf_renderer.rb
@@ -224,7 +224,7 @@ module Payday
         cell(pdf, number_to_currency(invoice.subtotal, invoice), align: :right)
       ]
 
-      if invoice.tax_rate > 0
+      if invoice.respond_to?(:tax_rate) && invoice.tax_rate > 0
         if invoice.tax_description.nil?
           tax_description = I18n.t("payday.invoice.tax", default: "Tax:")
         else
@@ -236,7 +236,7 @@ module Payday
           cell(pdf, number_to_currency(invoice.tax, invoice), align: :right)
         ]
       end
-      if invoice.shipping_rate > 0
+      if invoice.respond_to?(:shipping_rate) && invoice.shipping_rate > 0
         if invoice.shipping_description.nil?
           shipping_description =
             I18n.t("payday.invoice.shipping", default: "Shipping:")

--- a/lib/payday/pdf_renderer.rb
+++ b/lib/payday/pdf_renderer.rb
@@ -18,7 +18,9 @@ module Payday
       pdf = Prawn::Document.new(page_size: invoice_or_default(invoice, :page_size))
 
       # set up some default styling
-      pdf.font_size(8)
+      pdf.font_size(Payday::Config.default.pdf_font_size)
+      pdf.font_families.update(Payday::Config.default.pdf_font_families) if Payday::Config.default.pdf_font_families
+      pdf.font Payday::Config.default.pdf_font if Payday::Config.default.pdf_font
 
       stamp(invoice, pdf)
       company_banner(invoice, pdf)
@@ -45,7 +47,7 @@ module Payday
 
       if stamp
         pdf.bounding_box([150, pdf.cursor - 50], width: pdf.bounds.width - 300) do
-          pdf.font("Helvetica-Bold") do
+          pdf.font(Payday::Config.default.pdf_font) do
             pdf.fill_color "cc0000"
             pdf.text stamp, align: :center, size: 25, rotate: 15
           end
@@ -265,7 +267,7 @@ module Payday
     def self.notes(invoice, pdf)
       if defined?(invoice.notes) && invoice.notes
         pdf.move_cursor_to(pdf.cursor - 30)
-        pdf.font("Helvetica-Bold") do
+        pdf.font(Payday::Config.default.pdf_font) do
           pdf.text(I18n.t("payday.invoice.notes", default: "Notes"))
         end
         pdf.line_width = 0.5


### PR DESCRIPTION
I made some changes, like new invoice fields, czech translation, but more important - UTF8 support with customizable fonts, possibility to change font size and support TAX per line with summarization grouped taxes. Last change is title on invoice. This changes was required by Czech law.