### PR TITLE
Fix for ruby 2.4 (issue #53)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,5 +4,5 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_first_parameter

--- a/lib/payday/invoice.rb
+++ b/lib/payday/invoice.rb
@@ -26,12 +26,12 @@ module Payday
 
     # The tax rate that we're applying, as a BigDecimal
     def tax_rate=(value)
-      @tax_rate = BigDecimal.new(value.to_s)
+      @tax_rate = BigDecimal.new(value.nil? ? 0 : value.to_s)
     end
 
     # Shipping rate
     def shipping_rate=(value)
-      @shipping_rate = BigDecimal.new(value.to_s)
+      @shipping_rate = BigDecimal.new(value.nil? ? 0 : value.to_s)
     end
   end
 end


### PR DESCRIPTION
The changes restore the old behavior from ruby 2.3 where it was:

```
irb(main):003:0> BigDecimal.new ''
=> #<BigDecimal:5627144d57b0,'0.0',9(9)>
```
